### PR TITLE
[修正] 初期化時に、.techtrainフォルダーが存在しない場合のエラーハンドリングを実装

### DIFF
--- a/Assets/_techtrain/Editor/TechtrainExtension/ExtensionWindow.cs
+++ b/Assets/_techtrain/Editor/TechtrainExtension/ExtensionWindow.cs
@@ -56,7 +56,15 @@ namespace TechtrainExtension
             var label = new Label("Railway情報を読み込んでいます...");
             root.Add(label);
 
-            railwayManager = new RailwayManager(apiClient, false);
+            try{
+                railwayManager = new RailwayManager(apiClient, false);
+            }catch(System.Exception e){
+                Debug.LogError(e);
+                root.Clear();
+                root.Add(new Label("Railway情報の取得に失敗しました。時間をおいて再度試すか、運営までお問い合わせください"));
+                root.Add(new Button(() => { this.Reload(); }) { text = "再読み込み" });
+                return;
+            }
             await railwayManager.Initialize();
             if (railwayManager.IsClearAllStations())
             {


### PR DESCRIPTION
- throw をした際に上流でcatchをし忘れ、サイレントで死んでいたので修正

![{02B76AAA-F154-4A74-BD56-B6B524845056}](https://github.com/user-attachments/assets/39d00114-bdaf-47d0-b577-4d0c58e31faf)
.techtrainフォルダーが存在しない場合などにthrowしたエラーをcatchした場合の画面