### PR TITLE
[修正] ベースブランチ名変更に伴うworkflowの修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [master]
+    branches: [main]
 
   workflow_dispatch:
 


### PR DESCRIPTION
ref: https://github.com/TechBowl-japan/techtrain-unity-extension/pull/18#pullrequestreview-2742179282

ベースブランチ名を変更したことに伴い、workflowの対象ブランチ名をmaster -> mainに変更
