### PR TITLE
feat: 有料プラン制限を削除

### DIFF
--- a/Assets/_techtrain/Editor/TechtrainExtension/Api/Models/v3/RailwayStation.cs
+++ b/Assets/_techtrain/Editor/TechtrainExtension/Api/Models/v3/RailwayStation.cs
@@ -12,12 +12,6 @@ namespace TechtrainExtension.Api.Models.v3
         meeting
     }
 
-    public enum RailwayStationAccessLevel
-    {
-        free,
-        paid
-    }
-
     public enum UserRailwayStationStatus
     {
         not_challenging,
@@ -35,8 +29,6 @@ namespace TechtrainExtension.Api.Models.v3
         [JsonConverter(typeof(StringEnumConverter))]
         public RailwayStationConfirmationMethod confirmation_method { get; set; }
         public RailwayStationClearCondition[]? railway_station_clear_conditions { get; set; }
-        [JsonConverter(typeof(StringEnumConverter))]
-        public RailwayStationAccessLevel access_level { get; set; }
         public UserRailwayStation? user_railway_station { get; set; }
     }
 

--- a/Assets/_techtrain/Editor/TechtrainExtension/Api/Models/v3/UsersMeResponse.cs
+++ b/Assets/_techtrain/Editor/TechtrainExtension/Api/Models/v3/UsersMeResponse.cs
@@ -7,6 +7,5 @@ namespace TechtrainExtension.Api.Models.v3
         public int id { get; set; }
         public string? nickname { get; set; }
         public bool is_agreed_current_term { get; set; }
-        public bool is_paid	 { get; set; }
     }
 }

--- a/Assets/_techtrain/Editor/TechtrainExtension/ExtensionWindow.cs
+++ b/Assets/_techtrain/Editor/TechtrainExtension/ExtensionWindow.cs
@@ -72,7 +72,7 @@ namespace TechtrainExtension
 
                 try
                 {
-                    railwayManager = new RailwayManager(apiClient, user.data.is_paid);
+                    railwayManager = new RailwayManager(apiClient);
                 }
                 catch (System.Exception e)
                 {
@@ -110,11 +110,6 @@ namespace TechtrainExtension
                 if (currentStation.confirmation_method != Api.Models.v3.RailwayStationConfirmationMethod.unit_test)
                 {
                     root.Add(new Label("このStationは自動テストではないためUnity上でクリア判定が行えません。ブラウザ上から判定を行ってください"));
-                    return;
-                }
-                if (!railwayManager.IsStationPermitted(currentStation))
-                {
-                    root.Add(new Label("続きに挑戦するには、有料プランへの登録が必要です。"));
                     return;
                 }
                 var manifestStation = railwayManager.GetCurrentStationManifest();

--- a/Assets/_techtrain/Editor/TechtrainExtension/RailwayManager.cs
+++ b/Assets/_techtrain/Editor/TechtrainExtension/RailwayManager.cs
@@ -16,15 +16,11 @@ namespace TechtrainExtension
         private Api.Client apiClient;
         private Api.Models.v3.Railway? apiRailway;
 
-        private bool isUserPaid;
-
-
-        public RailwayManager(Api.Client _apiClient, bool _isUserPaid)
+        public RailwayManager(Api.Client _apiClient)
         {
             manifestsManager = new Manifests.Manager();
             manifestRailway = manifestsManager.GetRailway();
             apiClient = _apiClient;
-            isUserPaid = _isUserPaid;
         }
 
         public async Task<bool> Initialize()
@@ -97,19 +93,6 @@ namespace TechtrainExtension
                 }
             }
             return null;
-        }
-
-        public bool IsStationPermitted(RailwayStation station)
-        {
-            if (apiRailway == null)
-            {
-                return false;
-            }
-            if (station.access_level == RailwayStationAccessLevel.free)
-            {
-                return true;
-            }
-            return isUserPaid;
         }
 
         public Station? GetCurrentStationManifest()


### PR DESCRIPTION
## Summary
有料プランによるStation制限が不要になったため、関連するアクセス制御コードを削除する。
全Stationがプランによらずアクセスできるようになる。

## Changes
- `RailwayStation.cs`: `RailwayStationAccessLevel` enum と `access_level` プロパティを削除
- `UsersMeResponse.cs`: `is_paid` プロパティを削除
- `RailwayManager.cs`: `IsStationPermitted()` メソッド、`isUserPaid` フィールド、コンストラクタの `_isUserPaid` 引数を削除
- `ExtensionWindow.cs`: 有料プラン制限チェックと「続きに挑戦するには、有料プランへの登録が必要です。」メッセージを削除
- `package.json`: バージョンを 1.0.0 → 1.1.0 に更新

## Files Changed
- Modified: 5 files
- Lines: +3 / -34

## Architecture & Flow Diagram
```mermaid
flowchart TD
    A[Station選択] --> B{confirmation_method?}
    B -->|unit_test| C[テスト実行画面を表示]
    B -->|other| D[ブラウザ判定を案内]
    
    style A fill:#e8f5e9
    
    note["有料プラン制限チェックを削除\n全Stationに直接アクセス可能"]
    style note fill:#fff3e0,stroke:#ff9800
```

## Testing
- [ ] Unity Editor上での動作確認