### PR TITLE
chore: bump version to 1.1.0

### DIFF
--- a/Assets/_techtrain/package.json
+++ b/Assets/_techtrain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dev.techtrain.techtrain-unity-extension",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "displayName": "TechTrain Unity Extension",
   "description": "A Unity extension for TechTrain.",
   "unity": "2022.3",


### PR DESCRIPTION
## Summary
有料プラン制限削除に伴い、パッケージバージョンを 1.0.0 → 1.1.0 に更新する。

## Changes
- `Assets/_techtrain/package.json`: version を `1.0.0` → `1.1.0` に変更